### PR TITLE
fix: handle comments

### DIFF
--- a/lib/src/xmlpropertylistreader.dart
+++ b/lib/src/xmlpropertylistreader.dart
@@ -29,7 +29,7 @@ class XMLPropertyListReader {
     _requireDoctype();
     _requireStartElement('plist');
     _logStart('<plist>');
-    final event = _nextEventSkipOptionalText();
+    final event = _nextEventsSkipOptionalText();
     if (event is! XmlStartElementEvent) {
       throw _expected(
           event,
@@ -93,7 +93,7 @@ class XMLPropertyListReader {
       return list;
     }
     _logStart('<array>');
-    var event = _nextEventSkipOptionalText();
+    var event = _nextEventsSkipOptionalText();
     while (event is! XmlEndElementEvent) {
       if (event is! XmlStartElementEvent) {
         throw _expected(
@@ -102,7 +102,7 @@ class XMLPropertyListReader {
             'date,integer,real,true,false)');
       }
       list.add(_readObject(event));
-      event = _nextEventSkipOptionalText();
+      event = _nextEventsSkipOptionalText();
     }
     _logEnd('</array>');
     return list;
@@ -124,7 +124,7 @@ class XMLPropertyListReader {
       return dict;
     }
     _logStart('<dict>');
-    var event = _nextEventSkipOptionalText();
+    var event = _nextEventsSkipOptionalText();
     while (event is! XmlEndElementEvent) {
       // Read key
       if (event is! XmlStartElementEvent || (event.name != 'key')) {
@@ -146,7 +146,7 @@ class XMLPropertyListReader {
             'date,integer,real,true,false)');
       }
       dict[key] = _readObject(event);
-      event = _nextEventSkipOptionalText();
+      event = _nextEventsSkipOptionalText();
     }
     _logEnd('</dict>');
     return dict;
@@ -226,7 +226,7 @@ class XMLPropertyListReader {
   /// e.g. `<string>` where `string` is the [tagName] value.
 
   void _requireStartElement(String tagName) {
-    final event = _nextEventSkipOptionalText();
+    final event = _nextEventsSkipOptionalText();
     if (event is! XmlStartElementEvent || event.name != tagName) {
       throw _expected(event, tagName);
     }
@@ -238,7 +238,7 @@ class XMLPropertyListReader {
   /// e.g. </string> where `string` is the [tagName] value.
 
   void _requireEndElement(String tagName, {bool skipOptionalText = false}) {
-    final event = _nextEventSkipOptionalText();
+    final event = _nextEventsSkipOptionalText();
     if (event is! XmlEndElementEvent || event.name != tagName) {
       throw _expected(event, tagName);
     }
@@ -287,9 +287,9 @@ class XMLPropertyListReader {
   /// Throws a [PropertyListReadStreamException] if the end of the xml stream is
   /// encountered.
 
-  XmlEvent _nextEventSkipOptionalText() {
+  XmlEvent _nextEventsSkipOptionalText() {
     var event = _nextEvent();
-    if (event is XmlTextEvent) {
+    while (event is XmlTextEvent) {
       event = _nextEvent();
     }
     return event;

--- a/lib/src/xmlpropertylistreader.dart
+++ b/lib/src/xmlpropertylistreader.dart
@@ -29,7 +29,7 @@ class XMLPropertyListReader {
     _requireDoctype();
     _requireStartElement('plist');
     _logStart('<plist>');
-    final event = _nextEventsSkipOptionalText();
+    final event = _nextEventSkipOptionalTexts();
     if (event is! XmlStartElementEvent) {
       throw _expected(
           event,
@@ -93,7 +93,7 @@ class XMLPropertyListReader {
       return list;
     }
     _logStart('<array>');
-    var event = _nextEventsSkipOptionalText();
+    var event = _nextEventSkipOptionalTexts();
     while (event is! XmlEndElementEvent) {
       if (event is! XmlStartElementEvent) {
         throw _expected(
@@ -102,7 +102,7 @@ class XMLPropertyListReader {
             'date,integer,real,true,false)');
       }
       list.add(_readObject(event));
-      event = _nextEventsSkipOptionalText();
+      event = _nextEventSkipOptionalTexts();
     }
     _logEnd('</array>');
     return list;
@@ -124,7 +124,7 @@ class XMLPropertyListReader {
       return dict;
     }
     _logStart('<dict>');
-    var event = _nextEventsSkipOptionalText();
+    var event = _nextEventSkipOptionalTexts();
     while (event is! XmlEndElementEvent) {
       // Read key
       if (event is! XmlStartElementEvent || (event.name != 'key')) {
@@ -138,7 +138,7 @@ class XMLPropertyListReader {
       _requireEndElement('key');
       _log('<key>$key</key>');
       // Read value
-      event = _nextEvent();
+      event = _nextEventSkipOptionalTexts();
       if (event is! XmlStartElementEvent) {
         throw _expected(
             event,
@@ -146,7 +146,7 @@ class XMLPropertyListReader {
             'date,integer,real,true,false)');
       }
       dict[key] = _readObject(event);
-      event = _nextEventsSkipOptionalText();
+      event = _nextEventSkipOptionalTexts();
     }
     _logEnd('</dict>');
     return dict;
@@ -226,7 +226,7 @@ class XMLPropertyListReader {
   /// e.g. `<string>` where `string` is the [tagName] value.
 
   void _requireStartElement(String tagName) {
-    final event = _nextEventsSkipOptionalText();
+    final event = _nextEventSkipOptionalTexts();
     if (event is! XmlStartElementEvent || event.name != tagName) {
       throw _expected(event, tagName);
     }
@@ -238,7 +238,7 @@ class XMLPropertyListReader {
   /// e.g. </string> where `string` is the [tagName] value.
 
   void _requireEndElement(String tagName, {bool skipOptionalText = false}) {
-    final event = _nextEventsSkipOptionalText();
+    final event = _nextEventSkipOptionalTexts();
     if (event is! XmlEndElementEvent || event.name != tagName) {
       throw _expected(event, tagName);
     }
@@ -287,7 +287,7 @@ class XMLPropertyListReader {
   /// Throws a [PropertyListReadStreamException] if the end of the xml stream is
   /// encountered.
 
-  XmlEvent _nextEventsSkipOptionalText() {
+  XmlEvent _nextEventSkipOptionalTexts() {
     var event = _nextEvent();
     while (event is XmlTextEvent) {
       event = _nextEvent();

--- a/test/xmlpropertylistreader_test.dart
+++ b/test/xmlpropertylistreader_test.dart
@@ -394,6 +394,7 @@ void main() {
 <dict>
 	<!-- test -->
 	<key>com.apple.security.app-sandbox</key>
+  <!-- Hello! -->
 	<true/>
   <!-- 
     A multiline comment

--- a/test/xmlpropertylistreader_test.dart
+++ b/test/xmlpropertylistreader_test.dart
@@ -385,5 +385,29 @@ void main() {
       final o = p.parse() as String;
       expect(o, equals('My string\twith a tab'));
     });
+
+    test('comments', () {
+      const plistXml = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- test -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+  <!-- 
+    A multiline comment
+    Here's another line
+  -->
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>''';
+      final plist = XMLPropertyListReader(plistXml);
+      final map = plist.parse() as Map<String, Object>;
+      expect(map, hasLength(2));
+      expect(map['com.apple.security.app-sandbox'], equals(true));
+      expect(map['com.apple.security.network.server'], equals(true));
+    });
   });
 }


### PR DESCRIPTION
This was previously failing with the input provided in the new test. Skipping multiple sequential XmlTextEvents seems to solve the problem.

Failure message:

```
PropertyListReadStreamException: Expected XmlStartElementEvent (key), found XmlNodeType.TEXT `
```